### PR TITLE
[GameDialogHelper] Fix choices not being highlighted

### DIFF
--- a/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.Hooks.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.Hooks.cs
@@ -6,7 +6,6 @@ using ADV;
 using ADV.Commands.Base;
 using GeBoCommon.Utilities;
 using HarmonyLib;
-using TMPro;
 using Info = ActionGame.Communication.Info;
 
 namespace GameDialogHelperPlugin

--- a/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.Hooks.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.Hooks.cs
@@ -71,7 +71,7 @@ namespace GameDialogHelperPlugin
                     foreach (var choice in ___choices)
                     {
                         answerId++;
-                        var text = choice.transform.GetComponentInChildren<TextMeshProUGUI>();
+                        var text = choice.transform.GetComponentInChildren<UnityEngine.UI.Text>();
                         if (text == null) continue;
                         ApplyHighlightSelections(answerId, text);
                     }

--- a/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.cs
@@ -289,7 +289,7 @@ namespace GameDialogHelperPlugin
         }
 
 
-        internal static void ApplyHighlightSelections(int answerId, TextMeshProUGUI text)
+        internal static void ApplyHighlightSelections(int answerId, UnityEngine.UI.Text text)
         {
             text.color = DefaultColor;
             if (!CurrentlyEnabled) return;
@@ -333,7 +333,7 @@ namespace GameDialogHelperPlugin
             _logic.ProcessDialogAnswered(TargetHeroine, CurrentDialog, isCorrect);
         }
 
-        public static void DefaultApplyHighlightSelection(int answerId, TextMeshProUGUI text)
+        public static void DefaultApplyHighlightSelection(int answerId, UnityEngine.UI.Text text)
         {
             if (!CurrentlyEnabled) return;
             var isCorrect = answerId == CurrentDialog.CorrectAnswerId;

--- a/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/KK.GameDialogHelper.cs
@@ -15,7 +15,6 @@ using KKAPI;
 using KKAPI.Chara;
 using KKAPI.MainGame;
 using Manager;
-using TMPro;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.SceneManagement;

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Advanced.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Advanced.cs
@@ -62,7 +62,7 @@ namespace GameDialogHelperPlugin.PluginModeLogic
             heroine.Remember(dialogInfo.QuestionId, dialogInfo.SelectedAnswerId, isCorrect);
         }
 
-        public void ApplyHighlightSelection(int answerId, TextMeshProUGUI text)
+        public void ApplyHighlightSelection(int answerId, UnityEngine.UI.Text text)
         {
             if (GameDialogHelper.HighlightMode.Value == HighlightMode.ChangeColor)
             {

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Advanced.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Advanced.cs
@@ -4,7 +4,6 @@ using BepInEx.Logging;
 using GeBoCommon.Utilities;
 using JetBrains.Annotations;
 using Manager;
-using TMPro;
 using UnityEngine;
 using Random = UnityEngine.Random;
 

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Disabled.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Disabled.cs
@@ -1,6 +1,4 @@
-﻿using TMPro;
-
-namespace GameDialogHelperPlugin.PluginModeLogic
+﻿namespace GameDialogHelperPlugin.PluginModeLogic
 {
     public class Disabled : IPluginModeLogic
     {

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Disabled.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/Disabled.cs
@@ -25,6 +25,6 @@ namespace GameDialogHelperPlugin.PluginModeLogic
 
         public void ProcessDialogAnswered(SaveData.Heroine heroine, DialogInfo dialogInfo, bool isCorrect) { }
 
-        public void ApplyHighlightSelection(int answerId, TextMeshProUGUI text) { }
+        public void ApplyHighlightSelection(int answerId, UnityEngine.UI.Text text) { }
     }
 }

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/IPluginModeLogic.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/IPluginModeLogic.cs
@@ -1,6 +1,4 @@
-﻿using TMPro;
-
-namespace GameDialogHelperPlugin.PluginModeLogic
+﻿namespace GameDialogHelperPlugin.PluginModeLogic
 {
     public interface IPluginModeLogic
     {

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/IPluginModeLogic.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/IPluginModeLogic.cs
@@ -16,7 +16,7 @@ namespace GameDialogHelperPlugin.PluginModeLogic
 
         void ProcessDialogAnswered(SaveData.Heroine heroine, DialogInfo dialogInfo, bool isCorrect);
 
-        void ApplyHighlightSelection(int answerId, TextMeshProUGUI text);
+        void ApplyHighlightSelection(int answerId, UnityEngine.UI.Text text);
 
         //void OnCorrectAnswerSelected();
 

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/RelationshipBased.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/RelationshipBased.cs
@@ -1,6 +1,4 @@
-﻿using TMPro;
-
-namespace GameDialogHelperPlugin.PluginModeLogic
+﻿namespace GameDialogHelperPlugin.PluginModeLogic
 {
     public class RelationshipBased : IPluginModeLogic
 

--- a/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/RelationshipBased.cs
+++ b/src/GameDialogHelper/KK_GameDialogHelper/PluginModeLogic/RelationshipBased.cs
@@ -26,7 +26,7 @@ namespace GameDialogHelperPlugin.PluginModeLogic
 
         public void ProcessDialogAnswered(SaveData.Heroine heroine, DialogInfo dialogInfo, bool isCorrect) { }
 
-        public void ApplyHighlightSelection(int answerId, TextMeshProUGUI text)
+        public void ApplyHighlightSelection(int answerId, UnityEngine.UI.Text text)
         {
             GameDialogHelper.DefaultApplyHighlightSelection(answerId, text);
         }


### PR DESCRIPTION
Replacing all instances of `TextMeshProUGUI` with `UnityEngine.UI.Text` seems to make the plugin function as intended in both text append and color change modes.

According to #5 the plugin not functioning is specific to the Party version of the game, however, so in its current state this PR will probably break the functionality on the JP version (I don't have a copy to test with).